### PR TITLE
Adds hack to fix the parsing of star's (*) definition under ghc 8.6.5

### DIFF
--- a/library/CompoundTypes/Private/Lazy/Product.hs
+++ b/library/CompoundTypes/Private/Lazy/Product.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE NoStarIsType #-}
 module CompoundTypes.Private.Lazy.Product where
 
 
@@ -30,7 +31,7 @@ data Product7 _1 _2 _3 _4 _5 _6 _7 =
 -- In that case it will resolve to:
 -- 
 -- > Product3 Int Char Bool
-type family a * b where
+type family (a * b) where
 
   Product6 _1 _2 _3 _4 _5 _6 * _7 =
     Product7 _1 _2 _3 _4 _5 _6 _7
@@ -72,7 +73,7 @@ type family a * b where
   Undivided _1 _2 * _3 =
     Undivided (_1 * _3) _2
     
-  _1 * Product6 _2 _3 _4 _5 _6 _7 =
+  (*) _1 (Product6 _2 _3 _4 _5 _6 _7) =
     Product7 _1 _2 _3 _4 _5 _6 _7
   _1 * Product5 _2 _3 _4 _5 _6 =
     Product6 _1 _2 _3 _4 _5 _6

--- a/library/CompoundTypes/Private/Strict/Product.hs
+++ b/library/CompoundTypes/Private/Strict/Product.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE NoStarIsType #-}
 module CompoundTypes.Private.Strict.Product where
 
 
@@ -72,7 +73,7 @@ type family a * b where
   Undivided _1 _2 * _3 =
     Undivided (_1 * _3) _2
     
-  _1 * Product6 _2 _3 _4 _5 _6 _7 =
+  (*) _1 (Product6 _2 _3 _4 _5 _6 _7) =
     Product7 _1 _2 _3 _4 _5 _6 _7
   _1 * Product5 _2 _3 _4 _5 _6 =
     Product6 _1 _2 _3 _4 _5 _6


### PR DESCRIPTION
Building 'type family a * b where...' fails in ghc version 8.6.5. The changes here yield a
successful build, but seem to indicate a (ghc) parsing bug around the '*' symbol as an infix type
operator.